### PR TITLE
Remove explicit Mount from ci app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,16 @@
 # Run Continuous Integration (CI) Tests on Modal
 
-[This example repo](https://github.com/modal-labs/ci-on-modal)
-is a demonstration of one pattern for running tests on Modal:
-bring your existing package and test suite (here `my_pkg` and `tests`)
-and add a Modal App (`my_pkg.ci`)
-that mounts your tests
-and a Function (`pytest`) runs `pytest`.
+[This example repo](https://github.com/modal-labs/ci-on-modal) is a
+demonstration of one pattern for running tests on Modal: bring your existing
+package and test suite (here `my_pkg` and `tests`) and add a Modal App
+(`my_pkg.ci`) with a Function (`pytest`) that runs `pytest`.
 
 That's as straightforward as
 
 ```python
 # my_pkg/ci.py
-tests = modal.Mount.from_local_dir("path/to/tests", remote_path="/root/tests")
 
-
-@app.function(gpu="any", mounts=[tests])
+@app.function(gpu="any")
 def pytest():
     import subprocess
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ All commands below are run from the root of the repository.
 ### Run tests remotely on Modal
 
 ```bash
-modal run my_pkg.ci
+modal run -m my_pkg.ci
 ```
 
 On the first execution, the [container image](https://modal.com/docs/guide/custom-container)

--- a/my_pkg/ci.py
+++ b/my_pkg/ci.py
@@ -9,6 +9,7 @@ image = (
     .pip_install("pytest")
     .pip_install_from_requirements(ROOT_PATH / "requirements.txt")
     .add_local_dir(ROOT_PATH / "my_pkg", remote_path="/root/my_pkg")
+    .add_local_dir(ROOT_PATH / "tests", remote_path="/root/tests")
 )
 
 app = modal.App("ci-testing", image=image)

--- a/my_pkg/ci.py
+++ b/my_pkg/ci.py
@@ -8,7 +8,6 @@ image = (
     modal.Image.debian_slim()
     .pip_install("pytest")
     .pip_install_from_requirements(ROOT_PATH / "requirements.txt")
-    .add_local_dir(ROOT_PATH / "my_pkg", remote_path="/root/my_pkg")
     .add_local_dir(ROOT_PATH / "tests", remote_path="/root/tests")
 )
 

--- a/my_pkg/ci.py
+++ b/my_pkg/ci.py
@@ -8,15 +8,13 @@ image = (
     modal.Image.debian_slim()
     .pip_install("pytest")
     .pip_install_from_requirements(ROOT_PATH / "requirements.txt")
+    .add_local_dir(ROOT_PATH / "my_pkg", remote_path="/root/my_pkg")
 )
 
 app = modal.App("ci-testing", image=image)
 
-# mount: add local files to the remote container
-tests = modal.Mount.from_local_dir(ROOT_PATH / "tests", remote_path="/root/tests")
 
-
-@app.function(gpu="any", mounts=[tests])
+@app.function(gpu="any")
 def pytest():
     import subprocess
 


### PR DESCRIPTION
`modal.Mount` is deprecated; can be replaced with `modal.Image.add_local_dir`.